### PR TITLE
Fix a typo

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -110,7 +110,7 @@ per functionality in BigCloneBench.
 
 ### Step 4: Build the source code.
 
-From thje root directory, run `make`.
+From the root directory, run `make`.
 
 ### Step 5: Initialize the tools database
 


### PR DESCRIPTION
Typo was still in `ReadMe.md`, so I fixed it.